### PR TITLE
Projectile screen fix

### DIFF
--- a/Assets/_Scripts/PlayerCollision.cs
+++ b/Assets/_Scripts/PlayerCollision.cs
@@ -11,6 +11,7 @@ public class PlayerCollision : MonoBehaviour
         if (collider?.gameObject?.GetComponent<Projectile>())
         {
             Highscore.instance.DecrementScore(100);
+            Destroy(collider.gameObject);
             // TODO: play minecraft steve OOF sound clip.
         }
     }


### PR DESCRIPTION
Projectile now gets destroyed when it hits the player, so it doesn't get stuck on the screen